### PR TITLE
Fix (use a workaround for) GDI+ exception `0x80004005`

### DIFF
--- a/App/Extensions/NotifyIconExtensions.cs
+++ b/App/Extensions/NotifyIconExtensions.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Windows;
-using System.Windows.Controls;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using Wpf.Ui.Tray.Controls;
@@ -10,17 +9,6 @@ namespace Percentage.App.Extensions;
 internal static class NotifyIconExtensions
 {
     private const double DefaultNotifyIconSize = 16;
-
-    internal static void SetBatteryFullIcon(this NotifyIcon notifyIcon)
-    {
-        notifyIcon.SetIcon(new TextBlock
-        {
-            Text = "\uf5fc",
-            Foreground = BrushExtensions.GetBatteryNormalBrush(),
-            FontFamily = new FontFamily("Segoe Fluent Icons"),
-            FontSize = 16
-        });
-    }
 
     internal static void SetIcon(this NotifyIcon notifyIcon, FrameworkElement textBlock)
     {

--- a/App/NotifyIconWindow.xaml.cs
+++ b/App/NotifyIconWindow.xaml.cs
@@ -5,6 +5,7 @@ using System.Reactive.Subjects;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Forms;
+using System.Windows.Media;
 using System.Windows.Threading;
 using Windows.Devices.Power;
 using Microsoft.Win32;
@@ -35,6 +36,8 @@ public partial class NotifyIconWindow
 
     private string _notificationText;
     private string _notificationTitle;
+
+    private TextBlock _lastUsedTextBlock = new();
 
     public NotifyIconWindow()
     {
@@ -201,6 +204,15 @@ public partial class NotifyIconWindow
         _batteryStatusUpdateSubject.OnNext(false);
     }
 
+    private static bool AreTextBlocksEqual(TextBlock textBlock1, TextBlock textBlock2) =>
+        textBlock1.Text == textBlock2.Text &&
+        textBlock1.Foreground.ToString() == textBlock2.Foreground.ToString() &&
+        textBlock1.FontSize == textBlock2.FontSize &&
+        textBlock1.FontFamily.Source == textBlock2.FontFamily.Source &&
+        textBlock1.FontWeight == textBlock2.FontWeight &&
+        // Currently only underline decoration is supported, so TextDecorations.Count is both enough and short
+        textBlock1.TextDecorations.Count == textBlock2.TextDecorations.Count;
+
     private void SetNotifyIconText(string text, Brush foreground)
     {
         var textBlock = new TextBlock
@@ -216,6 +228,10 @@ public partial class NotifyIconWindow
 
         if (Default.TrayIconFontUnderline) textBlock.TextDecorations = TextDecorations.Underline;
 
+        if (AreTextBlocksEqual(_lastUsedTextBlock, textBlock))
+            return;
+
+        _lastUsedTextBlock = textBlock;
         NotifyIcon.SetIcon(textBlock);
     }
 

--- a/App/NotifyIconWindow.xaml.cs
+++ b/App/NotifyIconWindow.xaml.cs
@@ -235,6 +235,23 @@ public partial class NotifyIconWindow
         NotifyIcon.SetIcon(textBlock);
     }
 
+    private void SetBatteryFullIcon()
+    {
+        var textBlock = new TextBlock
+        {
+            Text = "\uf5fc",
+            Foreground = BrushExtensions.GetBatteryNormalBrush(),
+            FontFamily = new FontFamily("Segoe Fluent Icons"),
+            FontSize = 16
+        };
+
+        if (AreTextBlocksEqual(_lastUsedTextBlock, textBlock))
+            return;
+
+        _lastUsedTextBlock = textBlock;
+        NotifyIcon.SetIcon(textBlock);
+    }
+
     private void UpdateBatteryStatus()
     {
         var powerStatus = SystemInformation.PowerStatus;
@@ -265,7 +282,7 @@ public partial class NotifyIconWindow
             {
                 if (percent == 100)
                 {
-                    NotifyIcon.SetBatteryFullIcon();
+                    SetBatteryFullIcon();
 
                     var powerLineText = powerStatus.PowerLineStatus == PowerLineStatus.Online
                         ? " and connected to power"


### PR DESCRIPTION
Hello! First of all, thanks for your great app.

I recently thought that it would be great to try to fix the already legendary error:
```
System.Runtime.InteropServices.ExternalException (0x80004005): A generic error occurred in GDI+.
   at Windows.Win32.Graphics.GdiPlus.StatusExtensions.ThrowIfFailed(Status status)
   at System.Drawing.Bitmap.GetHicon()
   at Wpf.Ui.Tray.Hicon.FromSource(ImageSource source)
   at Wpf.Ui.Tray.TrayManager.ReloadHicon(INotifyIcon notifyIcon)
   at Wpf.Ui.Tray.TrayManager.ModifyIcon(INotifyIcon notifyIcon)
   at Wpf.Ui.Tray.Internal.InternalNotifyIconManager.ModifyIcon()
   at Wpf.Ui.Tray.Controls.NotifyIcon.OnIconChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
   at System.Windows.FrameworkElement.OnPropertyChanged(DependencyPropertyChangedEventArgs e)
   at System.Windows.DependencyObject.NotifyPropertyChange(DependencyPropertyChangedEventArgs args)
   at System.Windows.DependencyObject.UpdateEffectiveValue(EntryIndex entryIndex, DependencyProperty dp, PropertyMetadata metadata, EffectiveValueEntry oldEntry, EffectiveValueEntry& newEntry, Boolean coerceWithDeferredReference, Boolean coerceWithCurrentValue, OperationType operationType)
   at System.Windows.DependencyObject.SetValueCommon(DependencyProperty dp, Object value, PropertyMetadata metadata, Boolean coerceWithDeferredReference, Boolean coerceWithCurrentValue, OperationType operationType, Boolean isInternal)
   at System.Windows.DependencyObject.SetValue(DependencyProperty dp, Object value)
   at Wpf.Ui.Tray.Controls.NotifyIcon.set_Icon(ImageSource value)
```


### Disclaimer :)
Unfortunately, I am not familiar with C# and generally don't have enough programming experience, so my methods are quite limited. I treat my code pretty much as a vector of thought and not an implementation. The idea I came up with is not a fix, of course, just a workaround. But I believe it will work basically seamless to an end user.


### The idea
I experimented a bit and found that `notifyIcon.Icon =` is always incrementing the GDI handles count, even if the target bitmap was already rendered and cached _(unless we try to set the exact object that is already set)_. Bitmap creation itself also adds 2 to handles counter. This means 3 GDI handles for a bitmap is a baseline we can't get rid of (with a general limit of 10.000, [as we know](https://github.com/dotnet/wpf/issues/3067)).

So basically current implementation every 5 (10, 30, 60) seconds increments the handles counter for 3 which leads to $(10000 / 3) / (60 / 5) / 60 \approx 4.6$ hours of continuous work:
- $10000 / 3$ — approximate maximum of icons changes _(no need for forced GC calls by the way, automatic ones are enough)_,
- $60 / 5$ — icon changes amount per minute,
- $/ 60$ — convert minutes to hours.

The idea is to change the icon only when it's actually needed: when the font family/weight/decorations/size/color or the battery percent changes. This leads to ~3300 actual icon changes which means e.g. 30x more continuous work time: $(10000 / 3) * 3 / 60 \approx 167$ hours (~7 days) of continuous work if we take 3 minutes _(just a random number)_ as an average time to lose or gain a percent of battery power. I believe most users will just restart their devices faster then 167 hours of "clean" work time expire.


### An addition _(or the main point?..)_
Actually there is a more straightforward and short solution which by itself will prevent the exception. We could just programmatically check the amount of allocated GDI handles and just restart the application if it is approaching the limit. It is as simple (in my experiments, not sure about bundled app) as in 04d8be9876ebd92d775500bdafa4d561755130f8. Previous text and commits are basically not needed :)
Though, of course, restarting the app 10x times less often is better.


### Conclusion
I hope I introduced some meaningful ideas. Feel free to propose changes for my code, I'll try to fix it.

P.S. Don't you mind if I add `fixes #xxx` notes to automatically close the corresponding issues?