### PR TITLE
Fix RenderTargetBitmap crash in NotifyIconExtensions

### DIFF
--- a/App/Extensions/NotifyIconExtensions.cs
+++ b/App/Extensions/NotifyIconExtensions.cs
@@ -44,13 +44,24 @@ internal static class NotifyIconExtensions
         // may happen.
         // This is reported as https://github.com/dotnet/wpf/issues/3067.
         // Manually forcing a GC seems to help.
-        var renderTargetBitmap =
-            new RenderTargetBitmap(
-            (int)Math.Round(DefaultNotifyIconSize * dpiScale.DpiScaleX, MidpointRounding.AwayFromZero),
-            (int)Math.Round(DefaultNotifyIconSize * dpiScale.DpiScaleY, MidpointRounding.AwayFromZero),
-            dpiScale.PixelsPerInchX,
-            dpiScale.PixelsPerInchY,
-            PixelFormats.Default);
+        // var renderTargetBitmap =
+        //     new RenderTargetBitmap(
+        //     (int)Math.Round(DefaultNotifyIconSize * dpiScale.DpiScaleX, MidpointRounding.AwayFromZero),
+        //     (int)Math.Round(DefaultNotifyIconSize * dpiScale.DpiScaleY, MidpointRounding.AwayFromZero),
+        //     dpiScale.PixelsPerInchX,
+        //     dpiScale.PixelsPerInchY,
+        //     PixelFormats.Default);
+        // renderTargetBitmap.Render(textBlock);
+  
+        // Ensure width and height are at least 1
+        int width = Math.Max((int)Math.Round(DefaultNotifyIconSize * dpiScale.DpiScaleX, MidpointRounding.AwayFromZero), 1);
+        int height = Math.Max((int)Math.Round(DefaultNotifyIconSize * dpiScale.DpiScaleY, MidpointRounding.AwayFromZero), 1);
+
+        // Ensure DPI values are valid
+        double dpiX = Math.Max(dpiScale.PixelsPerInchX, 1);
+        double dpiY = Math.Max(dpiScale.PixelsPerInchY, 1);
+
+        var renderTargetBitmap = new RenderTargetBitmap(width, height, dpiX, dpiY, PixelFormats.Default);
         renderTargetBitmap.Render(textBlock);
 
         // Force GC after each RenderTargetBitmap creation to avoid running into COMException: MILERR_WIN32ERROR.


### PR DESCRIPTION
- Clamp width and height to be at least 1 to prevent GDI+ errors.
- Ensure DPI values are valid to avoid zero or negative values.
- Retain element measurement and centering logic for correct tray icon rendering.

This addresses issue #249, which was reported by multiple users experiencing crashes when the tray icon updates under certain DPI or display conditions.

Found this while opening the pull request. This might be a better solution: https://github.com/soleon/Percentage/pull/238